### PR TITLE
Fix 10 CVEs in arminc/clair-db

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,16 @@ language: go
 services:
   - docker
 
+env:
+  - POSTGRES_IMAGE=postgres:10.3-alpine CLAIR_LOCAL_SCAN_IMAGE=arminc/clair-local-scan:v2.0.1
+
 install:
   - docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
-  - docker pull postgres:10.3-alpine
-  - docker pull arminc/clair-local-scan:v2.0.1
-  - docker run -d --name postgres -e 'PGDATA=/var/lib/postgresql/clair' -e POSTGRES_PASSWORD=password postgres:10.3-alpine
+  - docker pull $POSTGRES_IMAGE
+  - docker pull $CLAIR_LOCAL_SCAN_IMAGE
+  - docker run -d --name postgres -e 'PGDATA=/var/lib/postgresql/clair' -e POSTGRES_PASSWORD=password $POSTGRES_IMAGE
   - sleep 20
-  - docker run -d --name clair --link postgres:postgres arminc/clair-local-scan:v2.0.1
+  - docker run -d --name clair --link postgres:postgres $CLAIR_LOCAL_SCAN_IMAGE
   
 script:
   - ./check.sh clair

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
 
 install:
   - docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
-  - docker pull postgres:alpine
+  - docker pull postgres:10.3-alpine
   - docker pull arminc/clair-local-scan:v2.0.1
   - docker run -d --name postgres -e 'PGDATA=/var/lib/postgresql/clair' -e POSTGRES_PASSWORD=password postgres:10.3-alpine
   - sleep 20

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
   - docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
   - docker pull postgres:alpine
   - docker pull arminc/clair-local-scan:v2.0.1
-  - docker run -d --name postgres -e 'PGDATA=/var/lib/postgresql/clair' -e POSTGRES_PASSWORD=password postgres:alpine
+  - docker run -d --name postgres -e 'PGDATA=/var/lib/postgresql/clair' -e POSTGRES_PASSWORD=password postgres:10.3-alpine
   - sleep 20
   - docker run -d --name clair --link postgres:postgres arminc/clair-local-scan:v2.0.1
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ services:
 
 install:
   - docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
-  - docker pull postgres:9.6.2-alpine
+  - docker pull postgres:alpine
   - docker pull arminc/clair-local-scan:v2.0.1
-  - docker run -d --name postgres -e 'PGDATA=/var/lib/postgresql/clair' -e POSTGRES_PASSWORD=password postgres:9.6.2-alpine
+  - docker run -d --name postgres -e 'PGDATA=/var/lib/postgresql/clair' -e POSTGRES_PASSWORD=password postgres:alpine
   - sleep 20
   - docker run -d --name clair --link postgres:postgres arminc/clair-local-scan:v2.0.1
   

--- a/check.sh
+++ b/check.sh
@@ -2,15 +2,15 @@
 
 while true
 do
-    docker logs clair | grep "update finished" >& /dev/null
+    docker logs "$1" | grep "update finished" >& /dev/null
     if [ $? == 0 ]; then
         break
     fi
 
-    docker logs clair | grep "an error occured" >& /dev/null
+    docker logs "$1" | grep "an error occured" >& /dev/null
     if [ $? == 0 ]; then
         echo "Error happend" >&2
-        docker logs clair
+        docker logs "$1"
         exit 1
     fi
 


### PR DESCRIPTION
I'm just writing a docker image scanning all locally running docker containers for CVEs: https://github.com/usr42/clair-container-scan

The docker image uses clair-scanner and the corresponding docker-compose.yml uses your clair-local-scan and clair-db.

So, the test run also scans these two images with clair and finds following issues for arminc/clair-db:
* CVE-2017-15873
* CVE-2017-16544
* CVE-2017-5969
* CVE-2017-16931
* CVE-2017-0379
* CVE-2017-15650
* CVE-2016-9840
* CVE-2016-9841
* CVE-2016-9843
* CVE-2016-9842

To fix this I upgraded the postgres base image to the latest postgres alpine image.
postgres:alpine has no known CVEs in clair.