### PR TITLE
Update to clair v2.0.2

### DIFF
--- a/clair/Dockerfile
+++ b/clair/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/coreos/clair:v2.0.1
+FROM quay.io/coreos/clair:v2.0.2
 
 COPY config.yaml /config/config.yaml
 


### PR DESCRIPTION
I've updated to the clair v2.0.2 base image. This image fixes some CVEs (one is unfortunately still there).
See also my other PR to fix the CVEs for arminc/clair-db: https://github.com/arminc/clair-local-scan/pull/6

This PR also addresses the [issue 5](https://github.com/arminc/clair-local-scan/issues/5)