### PR TITLE
Upgrade db base image to postgres:10.4-alpine

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
   - docker
 
 env:
-  - POSTGRES_IMAGE=postgres:10.3-alpine CLAIR_LOCAL_SCAN_IMAGE=arminc/clair-local-scan:v2.0.1
+  - POSTGRES_IMAGE=postgres:10.4-alpine CLAIR_LOCAL_SCAN_IMAGE=arminc/clair-local-scan:v2.0.1
 
 install:
   - docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"


### PR DESCRIPTION
postgres:10.3-alpine has 6 CVEs which are fixed by postgres:10.4-alpine:
* [CVE-2017-3738](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-3738)    MEDIUM    libcrypto1.0-1.0.2n-r0
* [CVE-2018-0733](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-0733)    MEDIUM    libcrypto1.0-1.0.2n-r0
* [CVE-2018-0739](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-0739)    MEDIUM    libcrypto1.0-1.0.2n-r0
* [CVE-2017-3738](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-3738)    MEDIUM    libssl1.0-1.0.2n-r0
* [CVE-2018-0733](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-0733)    MEDIUM    libssl1.0-1.0.2n-r0
* [CVE-2018-0739](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-0739)    MEDIUM    libssl1.0-1.0.2n-r0

See results for postgres:10.3-alpine:
https://anchore.io/image/dockerhub/24a77bfbb9ee3aeef9e24766ad6e9fa57f85c67596f154e8916e4f314067e149?repo=library%2Fpostgres&tag=10.3-alpine#security

See results for postgres:10.4-alpine:
https://anchore.io/image/dockerhub/f298e9fa532e9cedc50bf4744e2a4d903d04ef6ad52d349960d36006495f757e?repo=library%2Fpostgres&tag=10.4-alpine#security