### PR TITLE
Upgrade to clair v2.0.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
   - docker
 
 env:
-  - POSTGRES_IMAGE=postgres:10.4-alpine CLAIR_LOCAL_SCAN_IMAGE=arminc/clair-local-scan:v2.0.1
+  - POSTGRES_IMAGE=postgres:10.4-alpine CLAIR_LOCAL_SCAN_IMAGE=arminc/clair-local-scan:v2.0.4
 
 install:
   - docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Start the clair DB and clair locally or in your job
 
 ```bash
 docker run -d --name db arminc/clair-db:2017-03-15
-docker run -p 6060:6060 --link db:postgres -d --name clair arminc/clair-local-scan:v2.0.3
+docker run -p 6060:6060 --link db:postgres -d --name clair arminc/clair-local-scan:v2.0.4
 ```
 
 Having clair locally working is nice but you need to do something with it. You can either scan it with the 'official' analyze-local-images from CoreOS, or you can use a version modified by me. My version verifies which vulnerabilities are accepted and which are not (using a whitelist). You can find more info here <https://github.com/arminc/clair-scanner>

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/arminc/clair-local-scan.svg?branch=master)](https://travis-ci.org/arminc/clair-local-scan)
 
-CoreOs Clair <https://github.com/coreos/clair>, using the latest version 2.0.1
+CoreOs Clair <https://github.com/coreos/clair>, using the latest version 2.0.4
 
 You can run a dedicated clair server with a database but if you want to run clair standalone in your CI/CD pipeline then you are in a surprise:
 

--- a/clair/Dockerfile
+++ b/clair/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/coreos/clair:v2.0.3
+FROM quay.io/coreos/clair:v2.0.4
 
 COPY config.yaml /config/config.yaml
 


### PR DESCRIPTION
https://travis-ci.org/arminc/clair-local-scan/builds/403345975

```
{"Event":"could not branch Ubuntu repository",
"Level":"error",
"Location":"ubuntu.go:177",
"Time":"2018-07-12 23:24:14.995401",
"error":"exit status 3",
"output":"bzr: ERROR: Not a branch: \"https://launchpad.net/ubuntu-cve-tracker/\".\n"}
```

I believe this is fixed by https://github.com/coreos/clair/issues/524; the clair v2.0.4 docker image was pushed 3 days ago https://quay.io/repository/coreos/clair?tag=latest&tab=tags

fixes https://github.com/arminc/clair-local-scan/issues/13 (I believe)