### PR TITLE
Upgrade clair-db image to postgres:10.6-alpine

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
   - docker
 
 env:
-  - POSTGRES_IMAGE=postgres:10.4-alpine CLAIR_LOCAL_SCAN_IMAGE=arminc/clair-local-scan:v2.0.6
+  - POSTGRES_IMAGE=postgres:10.6-alpine CLAIR_LOCAL_SCAN_IMAGE=arminc/clair-local-scan:v2.0.6
 
 install:
   - docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"


### PR DESCRIPTION
Fixes CVEs in postgres base image:
https://anchore.io/image/dockerhub/962ed899c6097d137703c8a80ad73141aa185f65d646a221e8ba93abd9c924e0?repo=library%2Fpostgres&tag=10.4-alpine#security