### PR TITLE
Use clair:v2.0.7 to fix CVEs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
   - docker
 
 env:
-  - POSTGRES_IMAGE=postgres:10.4-alpine CLAIR_LOCAL_SCAN_IMAGE=arminc/clair-local-scan:v2.0.6
+  - POSTGRES_IMAGE=postgres:10.4-alpine CLAIR_LOCAL_SCAN_IMAGE=arminc/clair-local-scan:v2.0.7
 
 install:
   - docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Start the clair DB and clair locally or in your job
 
 ```bash
 docker run -d --name db arminc/clair-db:2017-03-15
-docker run -p 6060:6060 --link db:postgres -d --name clair arminc/clair-local-scan:v2.0.6
+docker run -p 6060:6060 --link db:postgres -d --name clair arminc/clair-local-scan:v2.0.7
 ```
 
 Having clair locally working is nice but you need to do something with it. You can either scan it with the 'official' analyze-local-images from CoreOS, or you can use a version modified by me. My version verifies which vulnerabilities are accepted and which are not (using a whitelist). You can find more info here <https://github.com/arminc/clair-scanner>

--- a/clair/Dockerfile
+++ b/clair/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/coreos/clair:v2.0.6
+FROM quay.io/coreos/clair:v2.0.7
 
 COPY config.yaml /config/config.yaml
 


### PR DESCRIPTION
clair v2.0.6 has CVEs: https://quay.io/repository/coreos/clair?tab=tags and https://quay.io/repository/coreos/clair/manifest/sha256:931edc5abc036bcc6cd8316e54217958fe27c00f71bbf45c72814563c6acd088?tab=vulnerabilities:

* CVE-2018-12384
* CVE-2018-17456 

2.0.7 has no CVEs yet.