### PR TITLE
Revert optimization which ends up causing very large (11GB) images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,15 @@ services:
   - docker
 
 env:
-  - CLAIR_VERSION=v2.0.7 CLAIR_LOCAL_SCAN_IMAGE=arminc/clair-local-scan
+  - POSTGRES_IMAGE=postgres:11.1-alpine CLAIR_VERSION=v2.0.7 CLAIR_LOCAL_SCAN_IMAGE=arminc/clair-local-scan
 
 install:
   - docker build -t $CLAIR_LOCAL_SCAN_IMAGE --build-arg VERSION=$CLAIR_VERSION clair
 
 before_script:
-  - docker run -d --name postgres -e 'PGDATA=/var/lib/postgresql/clair' -e POSTGRES_PASSWORD=password arminc/clair-db:$(date --date="-1 day" +%Y-%m-%d)
-  - until docker run --rm -it --link postgres:postgres -e PGPASSWORD=password postgres:11.1-alpine pg_isready -U postgres -h postgres; do sleep 1; done
+  - docker pull $POSTGRES_IMAGE
+  - docker run -d --name postgres -e 'PGDATA=/var/lib/postgresql/clair' -e POSTGRES_PASSWORD=password $POSTGRES_IMAGE
+  - until docker run --rm -it --link postgres:postgres -e PGPASSWORD=password $POSTGRES_IMAGE pg_isready -U postgres -h postgres; do sleep 1; done
   - docker run -d --name clair --link postgres:postgres $CLAIR_LOCAL_SCAN_IMAGE
 
 script:


### PR DESCRIPTION
Revert commit 04b8caa7d3c5bf9c2d45ad856c3cee171986b127 

On `master` the current images have grown to  11.1G (taken from travis build log)
```
$ docker images
REPOSITORY                TAG                                               IMAGE ID            CREATED                  SIZE
arminc/clair-db           2019-03-01                                        f04a32b8393a        Less than a second ago   11.1GB
arminc/clair-db           latest                                            f04a32b8393a        Less than a second ago   11.1GB
arminc/clair-local-scan   latest                                            5b0428de19c0        14 minutes ago           353MB
arminc/clair-local-scan   v2.0.7_01ffbeca4c205e35b59d74375ff628590a549e7a   5b0428de19c0        14 minutes ago           353MB
arminc/clair-db           2019-02-28                                        e2548b956e3c        24 hours ago             10.8GB
postgres                  11.1-alpine                                       b43856647ab5        3 weeks ago              70.8MB
quay.io/coreos/clair      v2.0.7                                            7968a46189ae        3 months ago             353MB
```

Sounds like this is caused by an attempt to optimize the build process by re-using the previous days image. Ideally this would work to save on build-time (we're not sure why it doesn't work yet).

Using a fresh postgres image seems to resolve the issue (we're back to what is normal):

```
$ docker images
REPOSITORY                  TAG                                               IMAGE ID            CREATED                  SIZE
nabadger/clair-db           2019-03-01                                        d573dea2334c        Less than a second ago   423MB
[secure]/clair-db            latest                                            d573dea2334c        Less than a second ago   423MB
nabadger/clair-local-scan   latest                                            236a41d1a5d0        19 minutes ago           353MB
nabadger/clair-local-scan   v2.0.7_50954a57dcd89aa58119090170349828c8714a52   236a41d1a5d0        19 minutes ago           353MB
postgres                    11.1-alpine                                       b43856647ab5        3 weeks ago              70.8MB
quay.io/coreos/clair        v2.0.7                                            7968a46189ae        3 months ago             353MB
```

I tried this against my own travis, output here: https://travis-ci.org/nabadger/clair-local-scan/builds/500519583
I've not yet used the image itself though...


