### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Start the Clair database and Clair locally or while running your job
 
 ```bash
 docker run -d --name db arminc/clair-db:latest
-docker run -p 6060:6060 --link db:postgres -d --name clair arminc/clair-local-scan:v2.0.8
+docker run -p 6060:6060 --link db:postgres -d --name clair arminc/clair-local-scan:v2.0.8_fe9b059d930314b54c78f75afe265955faf4fdc1
 ```
 
 Example of how to use today's date (for OSX)


### PR DESCRIPTION
Minor fix based on your new convention with hashed tags. 
An alternative could be to use `latest` 
Fixes the following error.
```
docker pull arminc/clair-local-scan:v2.0.8                                                                                                         
Error response from daemon: manifest for arminc/clair-local-scan:v2.0.8 not found
```