### PR TITLE
Issue #44 The clair-db container itself has a couple of HIGH CVEs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
   - docker
 
 env:
-  - POSTGRES_IMAGE=postgres:11.1-alpine CLAIR_VERSION=v2.1.0 CLAIR_LOCAL_SCAN_IMAGE=arminc/clair-local-scan
+  - POSTGRES_IMAGE=postgres:11.6-alpine CLAIR_VERSION=v2.1.0 CLAIR_LOCAL_SCAN_IMAGE=arminc/clair-local-scan
 
 install:
   - docker build -t $CLAIR_LOCAL_SCAN_IMAGE --build-arg VERSION=$CLAIR_VERSION clair


### PR DESCRIPTION
* Update the minor version on the upstream postgres container to get the vulnerability database container itself to scan cleanly