### PR TITLE
Updated Clair Version to v2.1.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
   - docker
 
 env:
-  - POSTGRES_IMAGE=postgres:11.6-alpine CLAIR_VERSION=v2.1.0 CLAIR_LOCAL_SCAN_IMAGE=arminc/clair-local-scan
+  - POSTGRES_IMAGE=postgres:11.6-alpine CLAIR_VERSION=v2.1.4 CLAIR_LOCAL_SCAN_IMAGE=arminc/clair-local-scan
 
 install:
   - docker build -t $CLAIR_LOCAL_SCAN_IMAGE --build-arg VERSION=$CLAIR_VERSION clair


### PR DESCRIPTION
There are multiple fixes between 2.1.0 and 2.1.4 that fixes issues related to scanning of RHEL images
Clair 2.1.0 does not work with UBI8 base images