### PR TITLE
Dump updater logs to travis build log

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ before_script:
 
 script:
   - ./check.sh
+  - docker logs clair
 
 after_success:
   - docker stop clair


### PR DESCRIPTION
Currently, the update process seem a bit shaky, DB updates are sometimes incomplete/inconsistent.
Apparently warning messages are written to the log, but they are chomped up by check.sh so they go unnoticed.
I'd propose to dump the log straight to Travis to provide some amount of traceability in the build log.
cf. https://github.com/arminc/clair-local-scan/issues/49