### PR TITLE
Catch warnings in check.sh and exit with rc=2

### DIFF
--- a/check.sh
+++ b/check.sh
@@ -9,11 +9,16 @@ do
         break
     fi
 
-    docker logs "$CONTAINER" | grep "an error occured" >& /dev/null
+    docker logs "$CONTAINER" | grep "error" >& /dev/null
     if [ $? == 0 ]; then
-        echo "Error happend" >&2
-        docker logs "$CONTAINER"
+        echo "Error during update." >&2
         exit 1
+    fi
+    
+    docker logs "$CONTAINER" | grep "warning" >& /dev/null
+    if [ $? == 0 ]; then
+        echo "Warning during update." >&2
+        exit 2
     fi
 
     echo -n "."


### PR DESCRIPTION
Sometimes NVD sources do not update correctly. This is displayed as warning in the updater logs. Criticality of the findings is broken when NVD data is missing. Thus, we should have warnings break the build here, also.