### PR TITLE
Upgrade to Clair v4.0.0-rc.24

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
   - docker
 
 env:
-  - POSTGRES_IMAGE=postgres:11.6-alpine CLAIR_VERSION=v2.1.6 CLAIR_LOCAL_SCAN_IMAGE=arminc/clair-local-scan
+  - POSTGRES_IMAGE=postgres:11.6-alpine CLAIR_VERSION=v4.0.0-rc.24 CLAIR_LOCAL_SCAN_IMAGE=arminc/clair-local-scan
 
 install:
   - docker build -t $CLAIR_LOCAL_SCAN_IMAGE --build-arg VERSION=$CLAIR_VERSION clair
@@ -38,6 +38,6 @@ deploy:
     branch: master
   script:
     docker push ${CLAIR_LOCAL_SCAN_IMAGE}:${CLAIR_VERSION}_${TRAVIS_COMMIT} &&
-    docker push $CLAIR_LOCAL_SCAN_IMAGE:latest && 
+    docker push $CLAIR_LOCAL_SCAN_IMAGE:latest &&
     docker push arminc/clair-db:$(date +%Y-%m-%d) &&
     docker push arminc/clair-db:latest

--- a/check.sh
+++ b/check.sh
@@ -4,17 +4,17 @@ CONTAINER="${1:-clair}"
 
 while true
 do
-    docker logs "$CONTAINER" | grep "update finished" >& /dev/null
+    docker logs "$CONTAINER" | grep "libvuln initialized" >& /dev/null
     if [ $? == 0 ]; then
         break
     fi
 
-    docker logs "$CONTAINER" | grep "error" >& /dev/null
+    docker logs "$CONTAINER" | grep "updating errors" >& /dev/null
     if [ $? == 0 ]; then
         echo "Error during update." >&2
         exit 1
     fi
-    
+
     docker logs "$CONTAINER" | grep "warning" >& /dev/null
     if [ $? == 0 ]; then
         echo "Warning during update." >&2

--- a/clair/Dockerfile
+++ b/clair/Dockerfile
@@ -4,4 +4,4 @@ FROM quay.io/coreos/clair:${VERSION}
 
 COPY config.yaml /config/config.yaml
 
-CMD ["-config=/config/config.yaml"]
+CMD ["-conf=/config/config.yaml"]

--- a/clair/config.yaml
+++ b/clair/config.yaml
@@ -11,70 +11,25 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-# The values specified here are the default values that Clair uses if no configuration file is specified or if the keys are not defined.
-clair:
-  database:
-    # Database driver
-    type: pgsql
-    options:
-      # PostgreSQL Connection string
-      # https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNSTRING
-      source: host=postgres port=5432 user=postgres password=password sslmode=disable statement_timeout=60000
-
-      # Number of elements kept in the cache
-      # Values unlikely to change (e.g. namespaces) are cached in order to save prevent needless roundtrips to the database.
-      cachesize: 16384
-
-  api:
-    # API server port
-    port: 6060
-
-    # Health server port
-    # This is an unencrypted endpoint useful for load balancers to check to healthiness of the clair server.
-    healthport: 6061
-
-    # Deadline before an API request will respond with a 503
-    timeout: 900s
-
-    # 32-bit URL-safe base64 key used to encrypt pagination tokens
-    # If one is not provided, it will be generated.
-    # Multiple clair instances in the same cluster need the same value.
-    paginationkey:
-
-    # Optional PKI configuration
-    # If you want to easily generate client certificates and CAs, try the following projects:
-    # https://github.com/coreos/etcd-ca
-    # https://github.com/cloudflare/cfssl
-    servername:
-    cafile:
-    keyfile:
-    certfile:
-
-  updater:
-    # Frequency the database will be updated with vulnerabilities from the default data sources
-    # The value 0 disables the updater entirely.
-    interval: 2h
-
-  notifier:
-    # Number of attempts before the notification is marked as failed to be sent
-    attempts: 3
-
-    # Duration before a failed notification is retried
-    renotifyinterval: 2h
-
-    http:
-      # Optional endpoint that will receive notifications via POST requests
-      endpoint:
-
-      # Optional PKI configuration
-      # If you want to easily generate client certificates and CAs, try the following projects:
-      # https://github.com/cloudflare/cfssl
-      # https://github.com/coreos/etcd-ca
-      servername:
-      cafile:
-      keyfile:
-      certfile:
-
-      # Optional HTTP Proxy: must be a valid URL (including the scheme).
-      proxy:
+---
+introspection_addr: localhost:6061
+http_listen_addr: localhost:6060
+log_level: debug
+indexer:
+  connstring: host=postgres port=5432 user=postgres password=password sslmode=disable statement_timeout=60000
+  scanlock_retry: 10
+  layer_scan_concurrency: 5
+  migrations: true
+matcher:
+  indexer_addr: "localhost:6060"
+  connstring: host=postgres port=5432 user=postgres password=password sslmode=disable statement_timeout=60000
+  max_conn_pool: 100
+  run: ""
+  migrations: true
+notifier:
+  indexer_addr: http://localhost:6060/
+  matcher_addr: http://localhost:6060/
+  connstring: host=postgres port=5432 user=postgres password=password sslmode=disable statement_timeout=60000
+  migrations: true
+  delivery_interval: 1m
+  poll_interval: 5m


### PR DESCRIPTION
While I was investigating why builds on https://travis-ci.org/arminc/clair-local-scan were failing and we have outdated images https://hub.docker.com/r/arminc/clair-db I have checked the possibility to upgrade to newest Clair (currently newest image is v4.0.0-rc.24: https://quay.io/repository/coreos/clair?tab=tags).

I have verified locally that database is updated, some texts were changed. Now when update finishes we see `libvuln initialized` instead of `update finished` and we can look for certain error related to updating database: `updating errors` instead of generic `error`.