### PR TITLE
upgrade to clair v2.1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
   - docker
 
 env:
-  - POSTGRES_IMAGE=postgres:11.6-alpine CLAIR_VERSION=v2.1.6 CLAIR_LOCAL_SCAN_IMAGE=arminc/clair-local-scan
+  - POSTGRES_IMAGE=postgres:11.6-alpine CLAIR_VERSION=v2.1.7 CLAIR_LOCAL_SCAN_IMAGE=arminc/clair-local-scan
 
 install:
   - docker build -t $CLAIR_LOCAL_SCAN_IMAGE --build-arg VERSION=$CLAIR_VERSION clair


### PR DESCRIPTION
Clair v2.1.7 fixes a panic on criterion 'Red Hat CoreOS <version> is installed' captured in https://github.com/quay/clair/issues/1249 and fixed in https://github.com/quay/clair/issues/1250