### PR TITLE
fix ubuntu-cve-tracker cloning error

### DIFF
--- a/clair/Dockerfile
+++ b/clair/Dockerfile
@@ -3,5 +3,6 @@ ARG  VERSION=latest
 FROM quay.io/coreos/clair:${VERSION}
 
 COPY config.yaml /config/config.yaml
+COPY gitconfig /etc/gitconfig
 
 CMD ["-config=/config/config.yaml"]

--- a/clair/gitconfig
+++ b/clair/gitconfig
@@ -1,0 +1,2 @@
+[url "git://git.launchpad.net/"]
+	insteadOf = https://git.launchpad.net/


### PR DESCRIPTION
The ubuntu-cve-tracker URL recently changed to only accept git protocol.  This patch uses a global gitconfig to map the corresponding https URL to git which resolves the cloning error.

Fixes #57
