### PR TITLE
fix: add EXPOSE instructions

### DIFF
--- a/clair/Dockerfile
+++ b/clair/Dockerfile
@@ -8,5 +8,6 @@ COPY config.yaml /config/config.yaml
 COPY gitconfig /etc/gitconfig
 
 # Copied from the original image
+EXPOSE 6060 6061
 ENTRYPOINT [ "/clair" ]
 CMD ["-config=/config/config.yaml"]


### PR DESCRIPTION
The flattened image introduced in https://github.com/arminc/clair-local-scan/pull/67 did not contain EXPOSE instructions (needed for those who relies on `-p` or `-P`, the PR fixes that.

Closes: https://github.com/arminc/clair-local-scan/issues/68